### PR TITLE
sonarcloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__/
 /.pydevproject
 tai5_uan5_gian5_gi2_kang1_ku7.egg-info/
 html/
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,13 @@ branches:
 jobs:
   include:
     - name: tanguan
-      addons:
-        sonarcloud:
-          organization: "ithuan"
-          token: ${SONAR_TOKEN}
       install:
         - pip install tox
       script:
         - tox -e tanguan
       after_success:
-        - sonar-scanner
+        - pip install awscli
+        - aws s3 cp coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-tanguan.xml
     - name: bunpun
       addons:
         sonarcloud:
@@ -42,10 +39,6 @@ jobs:
       after_success:
         - sonar-scanner
     - name: KenLM
-      addons:
-        sonarcloud:
-          organization: "ithuan"
-          token: ${SONAR_TOKEN}
       install:
         - pip install tox
       script:
@@ -57,6 +50,18 @@ jobs:
         - pip install tox
       script:
         - tox -e flake8
+    - stage: sonarcloud
+      addons:
+        sonarcloud:
+          organization: "ithuan"
+          token: ${SONAR_TOKEN}
+      name: coverage
+      install: skip
+      before_script:
+        - pip install awscli
+        - aws s3 sync s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/ .coverage-reports/
+      script:
+        - sonar-scanner
     - stage: deploy
       name: pypi
       if: branch ~= /\d+\.\d+\.\d+/

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,17 +42,6 @@ jobs:
       after_success:
         - sonar-scanner
     - name: KenLM
-      install:
-        - pip install tox
-      script:
-        - tox -e KenLM
-    - name: flake8
-      install:
-        - pip install tox
-      script:
-        - tox -e flake8
-    - stage: sonarcloud
-      name: coverage
       addons:
         sonarcloud:
           organization: "ithuan"
@@ -60,8 +49,14 @@ jobs:
       install:
         - pip install tox
       script:
-        - tox -e coverage
+        - tox -e KenLM
+      after_success:
         - sonar-scanner
+    - name: flake8
+      install:
+        - pip install tox
+      script:
+        - tox -e flake8
     - stage: deploy
       name: pypi
       if: branch ~= /\d+\.\d+\.\d+/

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ jobs:
         - tox -e flake8
     - stage: sonarcloud
       name: coverage
+      language: java
       jdk: openjdk17
       addons:
         sonarcloud:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: focal
+dist: jammy
 language: python
 python:
 - '3.8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,16 @@ branches:
 jobs:
   include:
     - name: tanguan
+      addons:
+        sonarcloud:
+          organization: "ithuan"
+          token: ${SONAR_TOKEN}
       install:
         - pip install tox
       script:
         - tox -e tanguan
       after_success:
-        - pip install python-coveralls
-        - coverage report
-        - coveralls
+        - sonar-scanner
     - name: bunpun
       install:
         - pip install tox
@@ -55,12 +57,7 @@ jobs:
           organization: "ithuan"
           token: ${SONAR_TOKEN}
       script:
-        - |
-          sonar-scanner \
-            -Dsonar.organization=ithuan \
-            -Dsonar.projectKey=ithuan_tai5-uan5_gian5-gi2_kang1-ku7 \
-            -Dsonar.sources=. \
-            -Dsonar.host.url=https://sonarcloud.io
+        - sonar-scanner
     - stage: deploy
       name: pypi
       if: branch ~= /\d+\.\d+\.\d+/

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,17 @@ jobs:
       after_success:
         - sonar-scanner
     - name: KenLM
+      install:
+        - pip install tox
+      script:
+        - tox -e KenLM
+    - name: flake8
+      install:
+        - pip install tox
+      script:
+        - tox -e flake8
+    - stage: sonarcloud
+      name: coverage
       addons:
         sonarcloud:
           organization: "ithuan"
@@ -49,14 +60,8 @@ jobs:
       install:
         - pip install tox
       script:
-        - tox -e KenLM
-      after_success:
+        - tox -e coverage
         - sonar-scanner
-    - name: flake8
-      install:
-        - pip install tox
-      script:
-        - tox -e flake8
     - stage: deploy
       name: pypi
       if: branch ~= /\d+\.\d+\.\d+/

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
         - tox -e tanguan
       after_success:
         - pip install awscli
-        - aws s3 cp coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-tanguan.xml
+        - aws s3 cp --endpoint-url ${AWS_S3_ENDPOINT_URL} coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-tanguan.xml
     - name: bunpun
       install:
         - pip install tox
@@ -23,7 +23,7 @@ jobs:
         - tox -e bunpun
       after_success:
         - pip install awscli
-        - aws s3 cp coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-bunpun.xml
+        - aws s3 cp --endpoint-url ${AWS_S3_ENDPOINT_URL} coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-bunpun.xml
     - name: HTS
       install:
         - pip install tox
@@ -31,7 +31,7 @@ jobs:
         - tox -e HTS
       after_success:
         - pip install awscli
-        - aws s3 cp coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-HTS.xml
+        - aws s3 cp --endpoint-url ${AWS_S3_ENDPOINT_URL} coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-HTS.xml
     - name: KenLM
       install:
         - pip install tox
@@ -39,7 +39,7 @@ jobs:
         - tox -e KenLM
       after_success:
         - pip install awscli
-        - aws s3 cp coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-KenLM.xml
+        - aws s3 cp --endpoint-url ${AWS_S3_ENDPOINT_URL} coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-KenLM.xml
     - name: flake8
       install:
         - pip install tox
@@ -54,7 +54,7 @@ jobs:
       install: skip
       before_script:
         - pip install awscli
-        - aws s3 sync s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/ .coverage-reports/
+        - aws s3 sync --endpoint-url ${AWS_S3_ENDPOINT_URL} s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/ .coverage-reports/
       script:
         - sonar-scanner
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,34 +17,29 @@ jobs:
         - pip install awscli
         - aws s3 cp coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-tanguan.xml
     - name: bunpun
-      addons:
-        sonarcloud:
-          organization: "ithuan"
-          token: ${SONAR_TOKEN}
       install:
         - pip install tox
       script:
         - tox -e bunpun
       after_success:
-        - sonar-scanner
+        - pip install awscli
+        - aws s3 cp coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-bunpun.xml
     - name: HTS
-      addons:
-        sonarcloud:
-          organization: "ithuan"
-          token: ${SONAR_TOKEN}
       install:
         - pip install tox
       script:
         - tox -e HTS
       after_success:
-        - sonar-scanner
+        - pip install awscli
+        - aws s3 cp coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-HTS.xml
     - name: KenLM
       install:
         - pip install tox
       script:
         - tox -e KenLM
       after_success:
-        - sonar-scanner
+        - pip install awscli
+        - aws s3 cp coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-KenLM.xml
     - name: flake8
       install:
         - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,34 +11,30 @@ jobs:
     - name: tanguan
       install:
         - pip install tox
+        - pip install awscli
       script:
         - tox -e tanguan
-      after_success:
-        - pip install awscli
         - aws s3 cp --endpoint-url ${AWS_S3_ENDPOINT_URL} coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-tanguan.xml
     - name: bunpun
       install:
         - pip install tox
+        - pip install awscli
       script:
         - tox -e bunpun
-      after_success:
-        - pip install awscli
         - aws s3 cp --endpoint-url ${AWS_S3_ENDPOINT_URL} coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-bunpun.xml
     - name: HTS
       install:
         - pip install tox
+        - pip install awscli
       script:
         - tox -e HTS
-      after_success:
-        - pip install awscli
         - aws s3 cp --endpoint-url ${AWS_S3_ENDPOINT_URL} coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-HTS.xml
     - name: KenLM
       install:
         - pip install tox
+        - pip install awscli
       script:
         - tox -e KenLM
-      after_success:
-        - pip install awscli
         - aws s3 cp --endpoint-url ${AWS_S3_ENDPOINT_URL} coverage.xml s3://${AWS_S3_BUCKET}/${TRAVIS_BUILD_NUMBER}/coverage-KenLM.xml
     - name: flake8
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,12 @@ jobs:
       script:
         - tox -e flake8
     - stage: sonarcloud
+      name: coverage
+      jdk: openjdk17
       addons:
         sonarcloud:
           organization: "ithuan"
           token: ${SONAR_TOKEN}
-      name: coverage
       install: skip
       before_script:
         - pip install awscli

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,44 +20,43 @@ jobs:
       after_success:
         - sonar-scanner
     - name: bunpun
+      addons:
+        sonarcloud:
+          organization: "ithuan"
+          token: ${SONAR_TOKEN}
       install:
         - pip install tox
       script:
         - tox -e bunpun
       after_success:
-        - pip install python-coveralls
-        - coverage report
-        - coveralls
+        - sonar-scanner
     - name: HTS
+      addons:
+        sonarcloud:
+          organization: "ithuan"
+          token: ${SONAR_TOKEN}
       install:
         - pip install tox
       script:
         - tox -e HTS
       after_success:
-        - pip install python-coveralls
-        - coverage report
-        - coveralls
+        - sonar-scanner
     - name: KenLM
+      addons:
+        sonarcloud:
+          organization: "ithuan"
+          token: ${SONAR_TOKEN}
       install:
         - pip install tox
       script:
         - tox -e KenLM
       after_success:
-        - pip install python-coveralls
-        - coverage report
-        - coveralls
+        - sonar-scanner
     - name: flake8
       install:
         - pip install tox
       script:
         - tox -e flake8
-    - name: sonarcloud
-      addons:
-        sonarcloud:
-          organization: "ithuan"
-          token: ${SONAR_TOKEN}
-      script:
-        - sonar-scanner
     - stage: deploy
       name: pypi
       if: branch ~= /\d+\.\d+\.\d+/

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,12 @@ jobs:
           organization: "ithuan"
           token: ${SONAR_TOKEN}
       script:
-        - sonar-scanner
+        - |
+          sonar-scanner
+            -Dsonar.organization=ithuan
+            -Dsonar.projectKey=ithuan_tai5-uan5_gian5-gi2_kang1-ku7
+            -Dsonar.sources=.
+            -Dsonar.host.url=https://sonarcloud.io
     - stage: deploy
       name: pypi
       if: branch ~= /\d+\.\d+\.\d+/

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,13 @@ jobs:
         - pip install tox
       script:
         - tox -e flake8
+    - name: sonarcloud
+      addons:
+        sonarcloud:
+          organization: "ithuan"
+          token: ${SONAR_TOKEN}
+      script:
+        - sonar-scanner
     - stage: deploy
       name: pypi
       if: branch ~= /\d+\.\d+\.\d+/

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,10 @@ jobs:
           token: ${SONAR_TOKEN}
       script:
         - |
-          sonar-scanner
-            -Dsonar.organization=ithuan
-            -Dsonar.projectKey=ithuan_tai5-uan5_gian5-gi2_kang1-ku7
-            -Dsonar.sources=.
+          sonar-scanner \
+            -Dsonar.organization=ithuan \
+            -Dsonar.projectKey=ithuan_tai5-uan5_gian5-gi2_kang1-ku7 \
+            -Dsonar.sources=. \
             -Dsonar.host.url=https://sonarcloud.io
     - stage: deploy
       name: pypi

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,4 +2,3 @@ sonar.organization=ithuan
 sonar.projectKey=ithuan_tai5-uan5_gian5-gi2_kang1-ku7
 sonar.sources=.
 sonar.host.url=https://sonarcloud.io
-sonar.python.coverage.reportPaths=coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,3 +2,4 @@ sonar.organization=ithuan
 sonar.projectKey=ithuan_tai5-uan5_gian5-gi2_kang1-ku7
 sonar.sources=.
 sonar.host.url=https://sonarcloud.io
+sonar.python.coverage.reportPaths=.coverage-reports/coverage-*.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.organization=ithuan
+sonar.projectKey=ithuan_tai5-uan5_gian5-gi2_kang1-ku7
+sonar.sources=.
+sonar.host.url=https://sonarcloud.io
+sonar.python.coverage.reportPaths=coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,13 @@ commands =
     coverage run --source=臺灣言語工具,試驗 -a -m unittest discover -p Test語言模型ppl整合試驗.py
     coverage xml
 
+[testenv:coverage]
+deps =
+    coverage
+commands =
+    coverage run --source=臺灣言語工具,試驗 -m unittest discover -p Test*.py
+    coverage xml
+
 [testenv:flake8]
 skip_install = True
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ deps =
     coverage
 commands =
     coverage run --source=臺灣言語工具,試驗 -m unittest discover -p *單元試驗.py
+    coverage xml
 
 [testenv:bunpun]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ commands =
     coverage run --source=臺灣言語工具,試驗 -m unittest discover -p Test字串*整合試驗.py
     coverage run --source=臺灣言語工具,試驗 -a -m unittest discover -p Test分詞*整合試驗.py
     coverage run --source=臺灣言語工具,試驗 -a -m unittest discover -p Test臺灣閩南語羅馬字拼音調符整合試驗.py
+    coverage xml
 
 [testenv:HTS]
 passenv = *
@@ -20,8 +21,9 @@ deps =
     pypi-kenlm
     coverage
 commands =
-    coverage run --source=臺灣言語工具,試驗 -a -m unittest discover -p Test語音合成文本整合試驗.py
+    coverage run --source=臺灣言語工具,試驗 -m unittest discover -p Test語音合成文本整合試驗.py
     coverage run --source=臺灣言語工具,試驗 -a -m unittest discover -p Test語音合成整合試驗.py
+    coverage xml
 
 [testenv:KenLM]
 passenv = *
@@ -32,6 +34,7 @@ commands =
     coverage run --source=臺灣言語工具,試驗 -m unittest discover -p Test標全漢全羅整合試驗.py
     coverage run --source=臺灣言語工具,試驗 -a -m unittest discover -p TestKenLM語言模型整合試驗.py
     coverage run --source=臺灣言語工具,試驗 -a -m unittest discover -p Test語言模型ppl整合試驗.py
+    coverage xml
 
 [testenv:flake8]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -36,13 +36,6 @@ commands =
     coverage run --source=臺灣言語工具,試驗 -a -m unittest discover -p Test語言模型ppl整合試驗.py
     coverage xml
 
-[testenv:coverage]
-deps =
-    coverage
-commands =
-    coverage run --source=臺灣言語工具,試驗 -m unittest discover -p Test*.py
-    coverage xml
-
 [testenv:flake8]
 skip_install = True
 deps =


### PR DESCRIPTION
## 做法

Tī ta̍k-ê有`coverage`ê 試驗，攏傳`coverage.xml`報告到S3。Tī做`sonar-scan`前，kā報告自S3 lia̍h--lo̍h-lâi。

## 備註
1. 因為本底試驗就有留`coverage`，所以就tī有`coverage`ê 試驗，做`sonar-scan`。若專案無想欲做coverage，就直接Automatic Analysis。
2. 選CI流程，才ē-tàng做coverage。
3. Travis CI設定，無講著愛補`sonar-project.properties` 檔案，是看別ê manual settings才知--ê。
4. coverage設定參考 https://docs.sonarcloud.io/enriching/test-coverage/python-test-coverage/
5. sonarcloud一定愛[人工merge](https://community.sonarsource.com/t/how-to-get-total-coverage-from-multiple-unit-test-runs/31719) coverage報告，無法度像coverall，job隨人上傳ka-tī ê報告。